### PR TITLE
pubspec | bump hmi_core to 2.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hmi_networking
 description: A Flutter package used in hmi_widgets which is helps to visualize states, values, changes and other artefacts from technological processes.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/a-givertzman/hmi_networking
 publish_to: none
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   hmi_core:
       git:
         url: https://github.com/a-givertzman/hmi_core.git
-        ref: 2.1.1
+        ref: 2.1.2
   shared_preferences: ^2.0.20
   async: ^2.11.0
 


### PR DESCRIPTION
Closes #57 